### PR TITLE
Fix for average with steps test

### DIFF
--- a/include/labeling_lee_2021_bmrs.h
+++ b/include/labeling_lee_2021_bmrs.h
@@ -192,6 +192,7 @@ public:
     }
     void PerformLabelingWithSteps() {
         double alloc_timing = Alloc();
+        InitCompressedData(data_compressed);
 
         perf_.start();
         FirstScan();
@@ -824,9 +825,6 @@ private:
     void FirstScan() {
         int w(img_.cols);
         int h(img_.rows);
-
-        //compress data
-        InitCompressedData(data_compressed);
 
         //generate merged data
         int h_merge = h / 2 + h % 2;

--- a/include/labeling_lee_2021_bmrs_old.h
+++ b/include/labeling_lee_2021_bmrs_old.h
@@ -168,6 +168,7 @@ public:
     }
     void PerformLabelingWithSteps() {
         double alloc_timing = Alloc();
+        InitCompressedData(data_compressed);
 
         perf_.start();
         FirstScan();
@@ -800,9 +801,6 @@ private:
     void FirstScan() {
         int w(img_.cols);
         int h(img_.rows);
-
-        //compress data
-        InitCompressedData(data_compressed);
 
         //generate merged data
         int h_merge = h / 2 + h % 2;

--- a/include/labeling_lee_2021_brts.h
+++ b/include/labeling_lee_2021_brts.h
@@ -102,6 +102,7 @@ public:
     }
     void PerformLabelingWithSteps() {
         double alloc_timing = Alloc();
+        InitCompressedData(data_compressed);
 
         perf_.start();
         FirstScan();
@@ -597,7 +598,6 @@ private:
         // No free for img_labels_ because it is required at the end of the algorithm 
     }
     void FirstScan() {
-        InitCompressedData(data_compressed);
         LabelsSolver::Setup();
         FindRuns(data_compressed.bits, img_.rows, data_compressed.data_width, data_runs.runs);
     }


### PR DESCRIPTION
The average with steps test for the binary algorithms are supposed to ignore the time for 1 byte to 1 bit per pixel conversion. 
I found that it's still included in the test for all three algorithms, so I fixed it. 