### PR TITLE
perf: faster relabeling for several variants including SAUF

### DIFF
--- a/include/labeling3D_PRED_2021.h
+++ b/include/labeling3D_PRED_2021.h
@@ -390,16 +390,12 @@ public:
 		// Second scan
 		LabelsSolver::Flatten();
 
+		const unsigned int voxels = h * w * d;
 		int * img_row = reinterpret_cast<int*>(img_labels_.data);
-		for (int s = 0; s < d; s++) {
-			for (int r = 0; r < h; r++) {
-				for (int c = 0; c < w; c++) {
-					img_row[c] = LabelsSolver::GetLabel(img_row[c]);
-				}
-				img_row += img_labels_.step[1] / sizeof(int);
-			}
+		for (unsigned int i = 0; i < voxels; i++) {
+			img_row[i] = LabelsSolver::GetLabel(img_row[i]);
 		}
-
+        
 		LabelsSolver::Dealloc(); // Memory deallocation of the labels solver
 
 	}
@@ -553,14 +549,10 @@ private:
 		unsigned int h = img_.size.p[1];
 		unsigned int w = img_.size.p[2];
 
+		const unsigned int voxels = h * w * d;
 		int * img_row = reinterpret_cast<int*>(img_labels_.data);
-		for (unsigned int s = 0; s < d; s++) {
-			for (unsigned int r = 0; r < h; r++) {
-				for (unsigned int c = 0; c < w; c++) {
-					img_row[c] = LabelsSolver::GetLabel(img_row[c]);
-				}
-				img_row += img_labels_.step.p[1] / sizeof(int);
-			}
+		for (unsigned int i = 0; i < voxels; i++) {
+			img_row[i] = LabelsSolver::GetLabel(img_row[i]);
 		}
 	}
 };

--- a/include/labeling3D_PREDpp_2021.h
+++ b/include/labeling3D_PREDpp_2021.h
@@ -391,15 +391,11 @@ public:
 		// Second scan
 		LabelsSolver::Flatten();
 
-		int * img_row = reinterpret_cast<int*>(img_labels_.data);
-		for (int s = 0; s < d; s++) {
-			for (int r = 0; r < h; r++) {
-				for (int c = 0; c < w; c++) {
-					img_row[c] = LabelsSolver::GetLabel(img_row[c]);
-				}
-				img_row += img_labels_.step[1] / sizeof(int);
-			}
-		}
+        const unsigned int voxels = h * w * d;
+        int * img_row = reinterpret_cast<int*>(img_labels_.data);
+        for (unsigned int i = 0; i < voxels; i++) {
+            img_row[i] = LabelsSolver::GetLabel(img_row[i]);
+        }
 
 		LabelsSolver::Dealloc(); // Memory deallocation of the labels solver
 
@@ -566,21 +562,17 @@ private:
 
 
 	void SecondScan() {
-		LabelsSolver::Flatten();
+        LabelsSolver::Flatten();
 
-		unsigned int d = img_.size.p[0];
-		unsigned int h = img_.size.p[1];
-		unsigned int w = img_.size.p[2];
+        unsigned int d = img_.size.p[0];
+        unsigned int h = img_.size.p[1];
+        unsigned int w = img_.size.p[2];
 
-		int * img_row = reinterpret_cast<int*>(img_labels_.data);
-		for (unsigned int s = 0; s < d; s++) {
-			for (unsigned int r = 0; r < h; r++) {
-				for (unsigned int c = 0; c < w; c++) {
-					img_row[c] = LabelsSolver::GetLabel(img_row[c]);
-				}
-				img_row += img_labels_.step.p[1] / sizeof(int);
-			}
-		}
+        const unsigned int voxels = h * w * d;
+        int * img_row = reinterpret_cast<int*>(img_labels_.data);
+        for (unsigned int i = 0; i < voxels; i++) {
+            img_row[i] = LabelsSolver::GetLabel(img_row[i]);
+        }
 	}
 };
 

--- a/include/labeling3D_SAUF_2021.h
+++ b/include/labeling3D_SAUF_2021.h
@@ -328,14 +328,10 @@ public:
         // Second scan
         LabelsSolver::Flatten();
 
+        const unsigned int voxels = h * w * d;
         int * img_row = reinterpret_cast<int*>(img_labels_.data);
-        for (unsigned int s = 0; s < d; s++) {
-            for (unsigned int r = 0; r < h; r++) {
-                for (unsigned int c = 0; c < w; c++) {
-                    img_row[c] = LabelsSolver::GetLabel(img_row[c]);
-                }
-                img_row += img_labels_.step[1] / sizeof(int);
-            }
+        for (unsigned int i = 0; i < voxels; i++) {
+            img_row[i] = LabelsSolver::GetLabel(img_row[i]);
         }
 
         LabelsSolver::Dealloc(); // Memory deallocation of the labels solver
@@ -446,14 +442,10 @@ private:
         unsigned int h = img_.size.p[1];
         unsigned int w = img_.size.p[2];
 
+        const unsigned int voxels = h * w * d;
         int * img_row = reinterpret_cast<int*>(img_labels_.data);
-        for (unsigned int s = 0; s < d; s++) {
-            for (unsigned int r = 0; r < h; r++) {
-                for (unsigned int c = 0; c < w; c++) {
-                    img_row[c] = LabelsSolver::GetLabel(img_row[c]);
-                }
-                img_row += img_labels_.step.p[1] / sizeof(int);
-            }
+        for (unsigned int i = 0; i < voxels; i++) {
+            img_row[i] = LabelsSolver::GetLabel(img_row[i]);
         }
     }
 };

--- a/include/labeling3D_SAUFpp_2021.h
+++ b/include/labeling3D_SAUFpp_2021.h
@@ -328,14 +328,10 @@ public:
         // Second scan
         LabelsSolver::Flatten();
 
+        const unsigned int voxels = h * w * d;
         int * img_row = reinterpret_cast<int*>(img_labels_.data);
-        for (unsigned int s = 0; s < d; s++) {
-            for (unsigned int r = 0; r < h; r++) {
-                for (unsigned int c = 0; c < w; c++) {
-                    img_row[c] = LabelsSolver::GetLabel(img_row[c]);
-                }
-                img_row += img_labels_.step[1] / sizeof(int);
-            }
+        for (unsigned int i = 0; i < voxels; i++) {
+            img_row[i] = LabelsSolver::GetLabel(img_row[i]);
         }
 
         LabelsSolver::Dealloc(); // Memory deallocation of the labels solver
@@ -461,14 +457,10 @@ private:
         unsigned int h = img_.size.p[1];
         unsigned int w = img_.size.p[2];
 
+        const unsigned int voxels = h * w * d;
         int * img_row = reinterpret_cast<int*>(img_labels_.data);
-        for (unsigned int s = 0; s < d; s++) {
-            for (unsigned int r = 0; r < h; r++) {
-                for (unsigned int c = 0; c < w; c++) {
-                    img_row[c] = LabelsSolver::GetLabel(img_row[c]);
-                }
-                img_row += img_labels_.step.p[1] / sizeof(int);
-            }
+        for (unsigned int i = 0; i < voxels; i++) {
+            img_row[i] = LabelsSolver::GetLabel(img_row[i]);
         }
     }
 };

--- a/include/labeling3D_naive.h
+++ b/include/labeling3D_naive.h
@@ -124,14 +124,10 @@ public:
 		// Second scan
 		LabelsSolver::Flatten();
 
+		const int voxels = img_labels_.size[0] * img_labels_.size[1] * img_labels_.size[2];
 		int * img_row = reinterpret_cast<int*>(img_labels_.data);
-		for (int z = 0; z < img_labels_.size[0]; z++) {
-			for (int y = 0; y < img_labels_.size[1]; y++) {
-				for (int x = 0; x < img_labels_.size[2]; x++) {
-					img_row[x] = LabelsSolver::GetLabel(img_row[x]);
-				}
-				img_row += img_labels_.step[1] / sizeof(int);
-			}
+		for (int i = 0; i < voxels; i++) {
+			img_row[i] = LabelsSolver::GetLabel(img_row[i]);
 		}
 
 		LabelsSolver::Dealloc(); // Memory deallocation of the labels solver
@@ -282,14 +278,10 @@ public:
 		// Second scan
 		LabelsSolver::Flatten();
 
+		const int voxels = img_labels_.size[0] * img_labels_.size[1] * img_labels_.size[2];
 		int * img_row = reinterpret_cast<int*>(img_labels_.data);
-		for (int z = 0; z < img_labels_.size[0]; z++) {
-			for (int y = 0; y < img_labels_.size[1]; y++) {
-				for (int x = 0; x < img_labels_.size[2]; x++) {
-					img_row[x] = LabelsSolver::GetLabel(img_row[x]);
-				}
-				img_row += img_labels_.step[1] / sizeof(int);
-			}
+		for (int i = 0; i < voxels; i++) {
+			img_row[i] = LabelsSolver::GetLabel(img_row[i]);
 		}
 	}
 };

--- a/include/labeling_PREDpp_2021.h
+++ b/include/labeling_PREDpp_2021.h
@@ -110,12 +110,10 @@ public:
     // Second scan
         n_labels_ = LabelsSolver::Flatten();
 
-        for (int r_i = 0; r_i < img_labels_.rows; ++r_i) {
-            unsigned int *b = img_labels_.ptr<unsigned int>(r_i);
-            unsigned int *e = b + img_labels_.cols;
-            for (; b != e; ++b) {
-                *b = LabelsSolver::GetLabel(*b);
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
 
         LabelsSolver::Dealloc();
@@ -248,12 +246,13 @@ private:
         // Second scan
         n_labels_ = LabelsSolver::Flatten();
 
-        for (int r_i = 0; r_i < img_labels_.rows; ++r_i) {
-            unsigned int *b = img_labels_.ptr<unsigned int>(r_i);
-            unsigned int *e = b + img_labels_.cols;
-            for (; b != e; ++b) {
-                *b = LabelsSolver::GetLabel(*b);
-            }
+        const unsigned int w(img_.cols);
+        const unsigned int h(img_.rows);
+
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
     }
 };

--- a/include/labeling_algorithms.h
+++ b/include/labeling_algorithms.h
@@ -85,7 +85,7 @@ public:
 
     virtual ~Labeling2D() = default;
 
-    virtual std::string CheckAlg() const { return LabelingCheckSingleton2D::GetCheckAlg(Conn, LabelBackground); }
+    virtual std::string CheckAlg() const override { return LabelingCheckSingleton2D::GetCheckAlg(Conn, LabelBackground); }
 
     virtual bool IsLabelBackground() const override { return LabelBackground; }
 
@@ -106,7 +106,7 @@ public:
 
     virtual ~Labeling3D() = default;
 
-    virtual std::string CheckAlg() const { return LabelingCheckSingleton3D::GetCheckAlg(Conn, LabelBackground); }
+    virtual std::string CheckAlg() const override { return LabelingCheckSingleton3D::GetCheckAlg(Conn, LabelBackground); }
 
     virtual bool IsLabelBackground() const override { return LabelBackground; }
 

--- a/include/labeling_grana_2016.h
+++ b/include/labeling_grana_2016.h
@@ -91,12 +91,10 @@ public:
     // Second scan
         n_labels_ = LabelsSolver::Flatten();
 
-        for (int r_i = 0; r_i < img_labels_.rows; ++r_i) {
-            unsigned int *b = img_labels_.ptr<unsigned int>(r_i);
-            unsigned int *e = b + img_labels_.cols;
-            for (; b != e; ++b) {
-                *b = LabelsSolver::GetLabel(*b);
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
 
         LabelsSolver::Dealloc();
@@ -287,12 +285,13 @@ private:
         // Second scan
         n_labels_ = LabelsSolver::Flatten();
 
-        for (int r_i = 0; r_i < img_labels_.rows; ++r_i) {
-            unsigned int *b = img_labels_.ptr<unsigned int>(r_i);
-            unsigned int *e = b + img_labels_.cols;
-            for (; b != e; ++b) {
-                *b = LabelsSolver::GetLabel(*b);
-            }
+        const unsigned int w(img_.cols);
+        const unsigned int h(img_.rows);
+
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
     }
 };

--- a/include/labeling_he_2008.h
+++ b/include/labeling_he_2008.h
@@ -249,13 +249,10 @@ public:
         n_labels_ = LabelsSolver::Flatten();
 
         // Second scan
-        for (int r_i = 0; r_i < img_labels_.rows; ++r_i) {
-            unsigned int* img_labels_row_start = img_labels_.ptr<unsigned int>(r_i);
-            unsigned int* img_labels_row_end = img_labels_row_start + img_labels_.cols;
-            unsigned int* img_labels_row = img_labels_row_start;
-            for (int c_i = 0; img_labels_row != img_labels_row_end; ++img_labels_row, ++c_i) {
-                *img_labels_row = LabelsSolver::GetLabel(*img_labels_row);
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
 
         LabelsSolver::Dealloc();
@@ -465,14 +462,13 @@ private:
     {
         n_labels_ = LabelsSolver::Flatten();
 
-        // Second scan
-        for (int r_i = 0; r_i < img_labels_.rows; ++r_i) {
-            unsigned int* img_labels_row_start = img_labels_.ptr<unsigned int>(r_i);
-            unsigned int* img_labels_row_end = img_labels_row_start + img_labels_.cols;
-            unsigned int* img_labels_row = img_labels_row_start;
-            for (int c_i = 0; img_labels_row != img_labels_row_end; ++img_labels_row, ++c_i) {
-                *img_labels_row = LabelsSolver::GetLabel(*img_labels_row);
-            }
+        const unsigned int w(img_.cols);
+        const unsigned int h(img_.rows);
+
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
     }
 

--- a/include/labeling_he_2014.h
+++ b/include/labeling_he_2014.h
@@ -236,11 +236,10 @@ public:
 
         n_labels_ = LabelsSolver::MemFlatten();
 
-        // Second scan
-        for (int r_i = 0; r_i < img_labels.rows; ++r_i) {
-            for (int c_i = 0; c_i < img_labels.cols; ++c_i) {
-                img_labels(r_i,c_i) = LabelsSolver::MemGetLabel(img_labels(r_i, c_i));
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::MemGetLabel(img_data[i]);
         }
 
         // Store total accesses in the output vector 'accesses'
@@ -363,18 +362,17 @@ private:
 #undef CONDITION_N4
 #undef CONDITION_N5
     }
-    void SecondScan() 
+    void SecondScan()
     {
         n_labels_ = LabelsSolver::Flatten();
 
-        // Second scan
-        for (int r_i = 0; r_i < img_labels_.rows; ++r_i) {
-            unsigned int *img_labels_row_start = img_labels_.ptr<unsigned int>(r_i);
-            unsigned int *img_labels_row_end = img_labels_row_start + img_labels_.cols;
-            unsigned int *img_labels_row = img_labels_row_start;
-            for (int c_i = 0; img_labels_row != img_labels_row_end; ++img_labels_row, ++c_i) {
-                *img_labels_row = LabelsSolver::GetLabel(*img_labels_row);
-            }
+        const unsigned int w(img_.cols);
+        const unsigned int h(img_.rows);
+
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
     }
 };

--- a/include/labeling_he_2014.h
+++ b/include/labeling_he_2014.h
@@ -122,13 +122,10 @@ public:
         n_labels_ = LabelsSolver::Flatten();
 
         // Second scan
-        for (int r_i = 0; r_i < img_labels_.rows; ++r_i) {
-            unsigned int *img_labels_row_start = img_labels_.ptr<unsigned int>(r_i);
-            unsigned int *img_labels_row_end = img_labels_row_start + img_labels_.cols;
-            unsigned int *img_labels_row = img_labels_row_start;
-            for (int c_i = 0; img_labels_row != img_labels_row_end; ++img_labels_row, ++c_i) {
-                *img_labels_row = LabelsSolver::GetLabel(*img_labels_row);
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
 
         LabelsSolver::Dealloc();
@@ -236,12 +233,13 @@ public:
 
         n_labels_ = LabelsSolver::MemFlatten();
 
-        const unsigned int pixels = h * w;
-        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
-        for (unsigned int i = 0; i < pixels; i++) {
-            img_data[i] = LabelsSolver::MemGetLabel(img_data[i]);
+        // Second scan
+        for (int r_i = 0; r_i < img_labels.rows; ++r_i) {
+            for (int c_i = 0; c_i < img_labels.cols; ++c_i) {
+                img_labels(r_i,c_i) = LabelsSolver::MemGetLabel(img_labels(r_i, c_i));
+            }
         }
-
+        
         // Store total accesses in the output vector 'accesses'
         accesses = std::vector<uint64_t>((int)MD_SIZE, 0);
 

--- a/include/labeling_sauf_4c.h
+++ b/include/labeling_sauf_4c.h
@@ -148,10 +148,10 @@ public:
         // Second scan
         n_labels_ = LabelsSolver::MemFlatten();
 
-        const unsigned int pixels = h * w;
-        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
-        for (unsigned int i = 0; i < pixels; i++) {
-            img_data[i] = LabelsSolver::MemGetLabel(img_data[i]);
+        for (int r = 0; r < h; ++r) {
+            for (int c = 0; c < w; ++c) {
+                img_labels(r, c) = LabelsSolver::MemGetLabel(img_labels(r, c));
+            }
         }
 
         // Store total accesses in the output vector 'accesses'

--- a/include/labeling_sauf_4c.h
+++ b/include/labeling_sauf_4c.h
@@ -150,10 +150,10 @@ public:
         // Second scan
         n_labels_ = LabelsSolver::MemFlatten();
 
-        for (int r = 0; r < h; ++r) {
-            for (int c = 0; c < w; ++c) {
-                img_labels(r, c) = LabelsSolver::MemGetLabel(img_labels(r, c));
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::MemGetLabel(img_data[i]);
         }
 
         // Store total accesses in the output vector 'accesses'
@@ -263,12 +263,13 @@ private:
     {
         n_labels_ = LabelsSolver::Flatten();
 
-        for (int r = 0; r < img_labels_.rows; ++r) {
-            unsigned * img_row_start = img_labels_.ptr<unsigned>(r);
-            unsigned * const img_row_end = img_row_start + img_labels_.cols;
-            for (; img_row_start != img_row_end; ++img_row_start) {
-                *img_row_start = LabelsSolver::GetLabel(*img_row_start);
-            }
+        const unsigned int w(img_.cols);
+        const unsigned int h(img_.rows);
+
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
     }
 };

--- a/include/labeling_sauf_4c.h
+++ b/include/labeling_sauf_4c.h
@@ -61,12 +61,10 @@ public:
         // Second scan
         n_labels_ = LabelsSolver::Flatten();
 
-        for (int r = 0; r < img_labels_.rows; ++r) {
-            unsigned * img_row_start = img_labels_.ptr<unsigned>(r);
-            unsigned * const img_row_end = img_row_start + img_labels_.cols;
-            for (; img_row_start != img_row_end; ++img_row_start) {
-                *img_row_start = LabelsSolver::GetLabel(*img_row_start);
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
 
         LabelsSolver::Dealloc(); // Memory deallocation of the labels solver

--- a/include/labeling_sauf_background.h
+++ b/include/labeling_sauf_background.h
@@ -69,12 +69,10 @@ public:
         // Second scan
         n_labels_ = LabelsSolver::Flatten();
 
-        for (int r = 0; r < img_labels_.rows; ++r) {
-            unsigned* img_row_start = img_labels_.ptr<unsigned>(r);
-            unsigned* const img_row_end = img_row_start + img_labels_.cols;
-            for (; img_row_start != img_row_end; ++img_row_start) {
-                *img_row_start = LabelsSolver::GetLabel(*img_row_start);
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
 
         LabelsSolver::Dealloc(); // Memory deallocation of the labels solver
@@ -168,10 +166,10 @@ public:
         // Second scan
         n_labels_ = LabelsSolver::MemFlatten();
 
-        const unsigned int pixels = h * w;
-        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
-        for (unsigned int i = 0; i < pixels; i++) {
-            img_data[i] = LabelsSolver::MemGetLabel(img_data[i]);
+        for (int r_i = 0; r_i < img_labels.rows; ++r_i) {
+            for (int c_i = 0; c_i < img_labels.cols; ++c_i) {
+                img_labels(r_i,c_i) = LabelsSolver::MemGetLabel(img_labels(r_i, c_i));
+            }
         }
 
         // Store total accesses in the output vector 'accesses'

--- a/include/labeling_sauf_background.h
+++ b/include/labeling_sauf_background.h
@@ -168,10 +168,10 @@ public:
         // Second scan
         n_labels_ = LabelsSolver::MemFlatten();
 
-        for (int r = 0; r < h; ++r) {
-            for (int c = 0; c < w; ++c) {
-                img_labels(r, c) = LabelsSolver::MemGetLabel(img_labels(r, c));
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::MemGetLabel(img_data[i]);
         }
 
         // Store total accesses in the output vector 'accesses'
@@ -296,12 +296,13 @@ private:
     {
         n_labels_ = LabelsSolver::Flatten();
 
-        for (int r = 0; r < img_labels_.rows; ++r) {
-            unsigned * img_row_start = img_labels_.ptr<unsigned>(r);
-            unsigned * const img_row_end = img_row_start + img_labels_.cols;
-            for (; img_row_start != img_row_end; ++img_row_start) {
-                *img_row_start = LabelsSolver::GetLabel(*img_row_start);
-            }
+        const unsigned int w(img_.cols);
+        const unsigned int h(img_.rows);
+
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
     }
 };

--- a/include/labeling_wu_2009.h
+++ b/include/labeling_wu_2009.h
@@ -158,12 +158,12 @@ public:
         // Second scan
         n_labels_ = LabelsSolver::MemFlatten();
 
-        for (int r = 0; r < h; ++r) {
-            for (int c = 0; c < w; ++c) {
-                img_labels(r, c) = LabelsSolver::MemGetLabel(img_labels(r, c));
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::MemGetLabel(img_data[i]);
         }
-
+        
         // Store total accesses in the output vector 'accesses'
         accesses = std::vector<uint64_t>((int)MD_SIZE, 0);
 
@@ -276,12 +276,13 @@ private:
     {
         n_labels_ = LabelsSolver::Flatten();
 
-        for (int r = 0; r < img_labels_.rows; ++r) {
-            unsigned * img_row_start = img_labels_.ptr<unsigned>(r);
-            unsigned * const img_row_end = img_row_start + img_labels_.cols;
-            for (; img_row_start != img_row_end; ++img_row_start) {
-                *img_row_start = LabelsSolver::GetLabel(*img_row_start);
-            }
+        const unsigned int w(img_.cols);
+        const unsigned int h(img_.rows);
+
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::MemGetLabel(img_data[i]);
         }
     }
 };

--- a/include/labeling_wu_2009.h
+++ b/include/labeling_wu_2009.h
@@ -66,12 +66,10 @@ public:
         // Second scan
         n_labels_ = LabelsSolver::Flatten();
 
-        for (int r = 0; r < img_labels_.rows; ++r) {
-            unsigned * img_row_start = img_labels_.ptr<unsigned>(r);
-            unsigned * const img_row_end = img_row_start + img_labels_.cols;
-            for (; img_row_start != img_row_end; ++img_row_start) {
-                *img_row_start = LabelsSolver::GetLabel(*img_row_start);
-            }
+        const unsigned int pixels = h * w;
+        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
+        for (unsigned int i = 0; i < pixels; i++) {
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
 
         LabelsSolver::Dealloc(); // Memory deallocation of the labels solver
@@ -158,12 +156,12 @@ public:
         // Second scan
         n_labels_ = LabelsSolver::MemFlatten();
 
-        const unsigned int pixels = h * w;
-        unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
-        for (unsigned int i = 0; i < pixels; i++) {
-            img_data[i] = LabelsSolver::MemGetLabel(img_data[i]);
+        for (int r = 0; r < h; ++r) {
+            for (int c = 0; c < w; ++c) {
+                img_labels(r, c) = LabelsSolver::MemGetLabel(img_labels(r, c));
+            }
         }
-        
+
         // Store total accesses in the output vector 'accesses'
         accesses = std::vector<uint64_t>((int)MD_SIZE, 0);
 
@@ -276,13 +274,13 @@ private:
     {
         n_labels_ = LabelsSolver::Flatten();
 
-        const unsigned int w(img_.cols);
-        const unsigned int h(img_.rows);
+        const unsigned int h(img_labels_.cols);
+        const unsigned int w(img_labels_.rows);
 
         const unsigned int pixels = h * w;
         unsigned int * img_data = reinterpret_cast<unsigned int*>(img_labels_.data);
         for (unsigned int i = 0; i < pixels; i++) {
-            img_data[i] = LabelsSolver::MemGetLabel(img_data[i]);
+            img_data[i] = LabelsSolver::GetLabel(img_data[i]);
         }
     }
 };

--- a/src/labeling_algorithms.cc
+++ b/src/labeling_algorithms.cc
@@ -135,7 +135,7 @@ void KernelMapSingleton::InitializeAlgorithm(const std::string& algorithm, const
             }));
         v.push_back(s);
     }
-    KernelMapSingleton::GetInstance().data_[algorithm] = move(v);
+    KernelMapSingleton::GetInstance().data_[algorithm] = std::move(v);
 }
 
 


### PR DESCRIPTION
Hi YACCLAB maintainers!

I was running some experiments on YACCLAB and noticed in profiling that relabeling was contributing more time than I expected for variants that work one-pixel/voxel at a time. It's not a huge amount of time, but it is a constant tax against these variants that makes them look worse than they are and in-between them, softens the contribution of a faster first-pass.

I also fixed some compiler warnings.

I re-ran the 8-connected benchmark to demonstrate that there is a material speedup on these variants. The chip was a Macbook Pro M3. I did run them simultaneously, but I think that should be ok on this machine.

I've attached the results of my runs.

Here are some samples though:

### Before

<img width="670" height="221" alt="image" src="https://github.com/user-attachments/assets/cb0a96d8-588f-4adb-9653-9edc636128f2" />

### After

<img width="583" height="179" alt="image" src="https://github.com/user-attachments/assets/d3f37b1a-1703-4731-924d-50d89814c403" />

I hope you find this a useful contribution. 

Sincerely,
Will Silversmith

[faster_relabel.zip](https://github.com/user-attachments/files/29213175/faster_relabel.zip)

[master.zip](https://github.com/user-attachments/files/29213199/master.zip)
